### PR TITLE
Bugfixes to library.

### DIFF
--- a/pkg/network/instance.go
+++ b/pkg/network/instance.go
@@ -107,7 +107,7 @@ func (m *InstanceManagerImpl) LocateInterface(network *types.VirtualNetwork, ins
 		return nil, err
 	}
 
-	_, err = types.VirtualMachineInterfaceByUuid(m.client, nic.GetUuid())
+	nic, err = types.VirtualMachineInterfaceByUuid(m.client, nic.GetUuid())
 	if err != nil {
 		log.Error("Get vmi %s: %v", nic.GetUuid(), err)
 		return nil, err


### PR DESCRIPTION
Initialize address allocator network when it is initially created.
Return the interface contents when it is created.
